### PR TITLE
Add prop for stock chart

### DIFF
--- a/react-native-ChartView.js
+++ b/react-native-ChartView.js
@@ -15,6 +15,7 @@ const Highcharts='Highcharts';
 class ChartWeb extends Component {
 
     static defaultProps = {
+        stock: false,
         config: {
             chart: {
                 type: "spline",
@@ -100,7 +101,8 @@ class ChartWeb extends Component {
                     </style>
                     <head>
                         <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
-                        <script src="https://code.highcharts.com/highcharts.js"></script>
+                        ${props.stock ? '<script src="https://code.highcharts.com/stock/highstock.js"></script>'
+                                      : '<script src="https://code.highcharts.com/highcharts.js"></script>'}
                         <script src="https://code.highcharts.com/modules/exporting.js"></script>
                         <script>
                         $(function () {


### PR DESCRIPTION
This will allow to load the *highstocks* library on top of highcharts based on a prop.

```js
<ChartView stock={true} />
```

Updated PR: https://github.com/TradingPal/react-native-highcharts/pull/11