### PR TITLE
Use the actual stockChart

### DIFF
--- a/react-native-ChartView.js
+++ b/react-native-ChartView.js
@@ -106,7 +106,7 @@ class ChartWeb extends Component {
                         <script src="https://code.highcharts.com/modules/exporting.js"></script>
                         <script>
                         $(function () {
-                            Highcharts.chart('container', `,
+                            Highcharts.${props.stock ? 'stockChart' : 'chart'}('container', `,
             end:`           );
                         });
                         </script>

--- a/react-native-ChartView.js
+++ b/react-native-ChartView.js
@@ -15,6 +15,7 @@ const Highcharts='Highcharts';
 class ChartWeb extends Component {
 
     static defaultProps = {
+        stock: false,
         config: {
             chart: {
                 type: "spline",
@@ -100,7 +101,8 @@ class ChartWeb extends Component {
                     </style>
                     <head>
                         <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
-                        <script src="https://code.highcharts.com/highcharts.js"></script>
+                        ${props.stock ? '<script src="https://code.highcharts.com/stock/highstock.js"></script>'
+                                      : '<script src="https://code.highcharts.com/highcharts.js"></script>'}
                         <script src="https://code.highcharts.com/modules/exporting.js"></script>
                         <script>
                         $(function () {

--- a/react-native-ChartView.js
+++ b/react-native-ChartView.js
@@ -147,6 +147,7 @@ class ChartWeb extends Component {
                     style={styles.full}
                     source={{ html: concatHTML, baseUrl: 'web/' }}
                     javaScriptEnabled={true}
+                    domStorageEnable={true}
                 />
             </View>
         );


### PR DESCRIPTION
A few days ago I opened PR #11 to use the Highcharts stock chart by replacing the included source file. This worked partially but only limited functionality was available from Highstocks this way. 

It's also necessary to call `Highcharts.stockChart` instead of `Highcharts.chart` on the container to load the full features of the stock chart.

Sorry for the (previous) incomplete PR.