### PR TITLE
Config parsing bug

### DIFF
--- a/react-native-ChartView.js
+++ b/react-native-ChartView.js
@@ -162,9 +162,9 @@ var flattenObject = function (obj, str='{') {
 
 var flattenText = function(item) {
     var str = ''
-    if (typeof item === 'object' && item.length == undefined) {
+    if (item && typeof item === 'object' && item.length == undefined) {
         str += flattenObject(item)
-    } else if (typeof item === 'object' && item.length !== undefined) {
+    } else if (item && typeof item === 'object' && item.length !== undefined) {
         str += '['
         item.forEach(function(k2) {
             str += `${flattenText(k2)}, `


### PR DESCRIPTION
There were some situations where `item` was null, which actually has the strange case in javascript: `typeof null === 'object'`, so this case caused an error on `item.length`. Deferring to the last case for when item is null works.