### PR TITLE
Cancel user-select to prevent users to see the  bubble on ios

### DIFF
--- a/App/index.js
+++ b/App/index.js
@@ -26,6 +26,8 @@ class ChartWeb extends Component {
                         right:0;
                         bottom:0;
                         position:absolute;
+                        user-select: none;
+                        -webkit-user-select: none;
                     }
                     </style>
                     <head>

--- a/react-native-highcharts.js
+++ b/react-native-highcharts.js
@@ -26,6 +26,8 @@ class ChartWeb extends Component {
                         right:0;
                         bottom:0;
                         position:absolute;
+                        user-select: none;
+                        -webkit-user-select: none;
                     }
                     </style>
                     <head>


### PR DESCRIPTION
When users are navigating throw the chart, sometimes they hold a tap and slide it. This behavior shows a native Safari popup with `Copy | Look Up | Share...` options.

![image](https://user-images.githubusercontent.com/4405147/30491361-6d744272-9a13-11e7-9e27-d55c64bc5ebf.png)

I opened this PR in order to prevent this behavior. Now, the popup will never appears.
