### PR TITLE
Support highcharts options

### DIFF
--- a/App/index.js
+++ b/App/index.js
@@ -39,6 +39,7 @@ class ChartWeb extends Component {
                         <script src="https://code.highcharts.com/modules/exporting.js"></script>
                         <script>
                         $(function () {
+                            Highcharts.setOptions(${JSON.stringify(this.props.options)});
                             Highcharts.${this.props.stock ? 'stockChart' : 'chart'}('container', `,
             end:`           );
                         });

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ render() {
 | stock     | false      |   Default false; use Highstock |
 | more     | false      |   Default false; use Highstock-more |
 | style | false      |   Style object to be passed onto the WebView |
-| options | false      |   Default empty; pass global and lag options |
+| options | false      |   Pass global and lang options from Highcharts |
 
 ## NOTE
 if not rendering in real device add this two props to the component

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React-Native Highcharts
 
-This is a react-native component for IOS and Android that uses [Highcharts](http://www.highcharts.com) where you send the configuration as a prop and the chart is rendered within a WebView 
+This is a react-native component for IOS and Android that uses [Highcharts](http://www.highcharts.com) where you send the configuration as a prop and the chart is rendered within a WebView
 
 ## Getting Started
 ```bat
@@ -83,8 +83,19 @@ render() {
                 }())
             }]
         };
+
+    const options = {
+        global: {
+            useUTC: false
+        },
+        lang: {
+            decimalPoint: ',',
+            thousandsSep: '.'
+        }
+    };
+
     return (
-      <ChartView style={{height:300}} config={conf}></ChartView>
+      <ChartView style={{height:300}} config={conf} options={options}></ChartView>
     );
 }
 ```
@@ -96,6 +107,7 @@ render() {
 | stock     | false      |   Default false; use Highstock |
 | more     | false      |   Default false; use Highstock-more |
 | style | false      |   Style object to be passed onto the WebView |
+| options | false      |   Default empty; pass global and lag options |
 
 ## NOTE
 if not rendering in real device add this two props to the component
@@ -107,4 +119,4 @@ domStorageEnabled={true}
 ## Stuff used to make this:
 
  * [Highcharts](http://www.highcharts.com/) for making the chart
- 
+

--- a/react-native-highcharts.js
+++ b/react-native-highcharts.js
@@ -39,6 +39,7 @@ class ChartWeb extends Component {
                         <script src="https://code.highcharts.com/modules/exporting.js"></script>
                         <script>
                         $(function () {
+                            Highcharts.setOptions(${JSON.stringify(this.props.options)});
                             Highcharts.${this.props.stock ? 'stockChart' : 'chart'}('container', `,
             end:`           );
                         });


### PR DESCRIPTION
Now is possible to pass Highcharts [global](http://api.highcharts.com/highcharts/global) and [lang](http://api.highcharts.com/highcharts/lang) options. Then, `react-native-highcharts` users can make internationalization, for example.

Let me know if you need more details.