### PR TITLE
Update readme adding chart's props documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ render() {
 | style | false      |   Style object to be passed onto the WebView |
 | options | false      |   Pass global and lang options from Highcharts |
 | guage | false      |   Import gauge library from highcharts |
+| scalesPageToFit | false      |   Default true; If false it does not allow the page to scales the WebView |
+| automaticallyAdjustContentInsets | false      |   Default true; If false it does not allow the chart to adjust its size automatically. |
 
 
 props added to WebView


### PR DESCRIPTION
Hi!
I love your library and the way you wraps Highcharts for react-native applications.

I think the lane `{...this.props}`added by @Infinity0106 is awesome. I was crazy trying to solve some rendering problems that causes that my charts renders with different sizes each time.

When I entered the code of this module and find ** scalesPageToFit** and ** automaticallyAdjustContentInsets** something came to my mind, and passing these two properties set to false to the ChartView solved my problem. 

I think this is the same problem that are shown in these issues:
- #23 
- #61 

Therefore, I have added the corresponding documentation to the README file because I think that it is very useful to know this configuration. 👍 