### PR TITLE
Updated WebView library (the one being used is gonna be removed) and iOS error

### DIFF
--- a/App/index.js
+++ b/App/index.js
@@ -79,6 +79,7 @@ class ChartWeb extends Component {
         return (
           <View style={this.props.style}>
               <WebView
+			  	  originWhitelist={["file://"]}
                   onLayout={this.reRenderWebView}
                   style={styles.full}
                   source={{ html: concatHTML, baseUrl: 'web/' }}

--- a/App/index.js
+++ b/App/index.js
@@ -4,10 +4,10 @@ import {
     StyleSheet,
     Text,
     View,
-    WebView,
     Image,
     Dimensions
 } from 'react-native';
+import { WebView } from 'react-native-webview';
 
 const win = Dimensions.get('window');
 class ChartWeb extends Component {
@@ -60,7 +60,7 @@ class ChartWeb extends Component {
     }
 
     // used to resize on orientation of display
-    reRenderWebView(e) {
+    reRenderWebView = (e) => {
         this.setState({
             height: e.nativeEvent.layout.height,
             width: e.nativeEvent.layout.width,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-highcharts",
-  "version": "1.1",
+  "version": "1.1.0",
   "description":
     "JavaScript implementation of a view container that can flip between its front and back, where the back has a console.log and the front is your aplication.",
   "main": "react-native-highcharts.js",

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "bugs": {
     "url": "https://github.com/TradingPal/react-native-highcharts/issues"
   },
-  "homepage": "https://github.com/TradingPal/react-native-highcharts#readme"
+  "homepage": "https://github.com/TradingPal/react-native-highcharts#readme",
+  "dependencies": {
+    "react-native-webview": "^5.6.2"
+  }
 }

--- a/react-native-highcharts.js
+++ b/react-native-highcharts.js
@@ -79,6 +79,7 @@ class ChartWeb extends Component {
         return (
           <View style={this.props.style}>
               <WebView
+			  	  originWhitelist={["file://"]}
                   onLayout={this.reRenderWebView}
                   style={styles.full}
                   source={{ html: concatHTML, baseUrl: 'web/' }}

--- a/react-native-highcharts.js
+++ b/react-native-highcharts.js
@@ -4,10 +4,10 @@ import {
     StyleSheet,
     Text,
     View,
-    WebView,
     Image,
     Dimensions
 } from 'react-native';
+import { WebView } from 'react-native-webview';
 
 const win = Dimensions.get('window');
 class ChartWeb extends Component {
@@ -60,7 +60,7 @@ class ChartWeb extends Component {
     }
 
     // used to resize on orientation of display
-    reRenderWebView(e) {
+    reRenderWebView = (e) => {
         this.setState({
             height: e.nativeEvent.layout.height,
             width: e.nativeEvent.layout.width,


### PR DESCRIPTION
According to the [React Native Docs](https://facebook.github.io/react-native/docs/webview) the `<WebView/>` is going to be removed from React Native core and we should instead use [react-native-community/react-native-webview](https://github.com/react-native-community/react-native-webview).