### PR TITLE
added charts datetime localization support

### DIFF
--- a/App/index.js
+++ b/App/index.js
@@ -39,9 +39,43 @@ class ChartWeb extends Component {
                         ${this.props.guage ? '<script src="https://code.highcharts.com/modules/solid-gauge.js"></script>'
                                       : ''}
                         <script src="https://code.highcharts.com/modules/exporting.js"></script>
+                        <script src="https://unpkg.com/jalali-moment/dist/jalali-moment.browser.js"></script>
                         <script>
                         $(function () {
                             Highcharts.setOptions(${JSON.stringify(this.props.options)});
+                            moment.locale('${this.props.locale}');
+                            Highcharts.dateFormats = {
+                                a: function(ts) {
+                                  return moment(ts).format('dddd');
+                                },
+                                A: function(ts) {
+                                  return moment(ts).format('dddd');
+                                },
+                                d: function(ts) {
+                                  return moment(ts).format('DD');
+                                },
+                                e: function(ts) {
+                                  return moment(ts).format('D');
+                                },
+                                b: function(ts) {
+                                  return moment(ts).format('MMMM');
+                                },
+                                B: function(ts) {
+                                  return moment(ts).format('MMMM');
+                                },
+                                m: function(ts) {
+                                  return moment(ts).format('MM');
+                                },
+                                y: function(ts) {
+                                  return moment(ts).format('YY');
+                                },
+                                Y: function(ts) {
+                                  return moment(ts).format('YYYY');
+                                },
+                                W: function(ts) {
+                                  return moment(ts).format('ww');
+                                },
+                            };
                             Highcharts.${this.props.stock ? 'stockChart' : 'chart'}('container', `,
             end:`           );
                         });

--- a/react-native-highcharts.js
+++ b/react-native-highcharts.js
@@ -39,9 +39,43 @@ class ChartWeb extends Component {
                         ${this.props.guage ? '<script src="https://code.highcharts.com/modules/solid-gauge.js"></script>'
                                       : ''}
                         <script src="https://code.highcharts.com/modules/exporting.js"></script>
+                        <script src="https://unpkg.com/jalali-moment/dist/jalali-moment.browser.js"></script>
                         <script>
                         $(function () {
                             Highcharts.setOptions(${JSON.stringify(this.props.options)});
+                            moment.locale('${this.props.locale}');
+                            Highcharts.dateFormats = {
+                                a: function(ts) {
+                                  return moment(ts).format('dddd');
+                                },
+                                A: function(ts) {
+                                  return moment(ts).format('dddd');
+                                },
+                                d: function(ts) {
+                                  return moment(ts).format('DD');
+                                },
+                                e: function(ts) {
+                                  return moment(ts).format('D');
+                                },
+                                b: function(ts) {
+                                  return moment(ts).format('MMMM');
+                                },
+                                B: function(ts) {
+                                  return moment(ts).format('MMMM');
+                                },
+                                m: function(ts) {
+                                  return moment(ts).format('MM');
+                                },
+                                y: function(ts) {
+                                  return moment(ts).format('YY');
+                                },
+                                Y: function(ts) {
+                                  return moment(ts).format('YYYY');
+                                },
+                                W: function(ts) {
+                                  return moment(ts).format('ww');
+                                },
+                            };
                             Highcharts.${this.props.stock ? 'stockChart' : 'chart'}('container', `,
             end:`           );
                         });


### PR DESCRIPTION
By this PR we can pass a locale String as prop and all data and time will be localized

props name: `locale` and it is optional for backward compatibility

By using this code

`<ChartView style={{height:300}} config={conf} options={options} stock={true} **locale={'fa'}**></ChartView>`

![Screenshot_1563879823](https://user-images.githubusercontent.com/13766432/61707321-73ee3480-ad5f-11e9-8811-3f5816f51d73.png)

`<ChartView style={{height:300}} config={conf} options={options} stock={true}></ChartView>`

![Screenshot_1563879791](https://user-images.githubusercontent.com/13766432/61707336-7c466f80-ad5f-11e9-9947-bc5a25a80c9c.png)
