### PR TITLE
Add webview package to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "bugs": {
     "url": "https://github.com/TradingPal/react-native-highcharts/issues"
   },
+  "dependencies": {
+    "react-native-webview": "^7.4.1",
+  }
   "homepage": "https://github.com/TradingPal/react-native-highcharts#readme"
 }


### PR DESCRIPTION
Web View has been depriciated from core react-native and needs to be added from a new package called react-native-webview